### PR TITLE
chore: update bundler, remove discontinued gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Or install it yourself as:
 
     $ gem install threema
 
+Make sure that your operating system has `libsodium` installed. See here: https://github.com/RubyCrypto/rbnacl/wiki/Installing-libsodium
+
 ## Usage
 
 ### Account creation

--- a/lib/threema/e2e.rb
+++ b/lib/threema/e2e.rb
@@ -1,4 +1,3 @@
-require 'rbnacl/libsodium'
 require 'rbnacl'
 
 class Threema

--- a/lib/threema/e2e/key.rb
+++ b/lib/threema/e2e/key.rb
@@ -1,4 +1,3 @@
-require 'rbnacl/libsodium'
 require 'rbnacl'
 require 'openssl'
 require 'threema/util'

--- a/lib/threema/e2e/public_key.rb
+++ b/lib/threema/e2e/public_key.rb
@@ -1,4 +1,3 @@
-require 'rbnacl/libsodium'
 require 'rbnacl'
 
 class Threema

--- a/lib/threema/e2e/secret_key.rb
+++ b/lib/threema/e2e/secret_key.rb
@@ -1,4 +1,3 @@
-require 'rbnacl/libsodium'
 require 'rbnacl'
 
 class Threema

--- a/threema.gemspec
+++ b/threema.gemspec
@@ -26,9 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'multipart-post'
   spec.add_runtime_dependency 'mime-types'
   spec.add_runtime_dependency 'dotenv'
-  spec.add_runtime_dependency 'rbnacl-libsodium'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake', '~> 12'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'factory_girl', '~> 4.0'


### PR DESCRIPTION
* Bundler 2.x works just fine
* `rbnacl-libsodium` is discontinued, see here: https://github.com/RubyCrypto/rbnacl-libsodium#discontinued

The suggested way is to ask developers to install `libsodium` locally.