### PR TITLE
Add simple Threema::Receive::DeliveryReceipt

### DIFF
--- a/lib/threema/receive.rb
+++ b/lib/threema/receive.rb
@@ -7,6 +7,7 @@ require 'threema/util'
 require 'threema/receive/text'
 require 'threema/receive/image'
 require 'threema/receive/file'
+require 'threema/receive/delivery_receipt'
 
 class Threema
   module Receive

--- a/lib/threema/receive/delivery_receipt.rb
+++ b/lib/threema/receive/delivery_receipt.rb
@@ -1,0 +1,11 @@
+class Threema
+  module Receive
+    class DeliveryReceipt
+      attr_reader :content
+
+      def initialize(content:, **)
+        @content = content
+      end
+    end
+  end
+end


### PR DESCRIPTION
We would ignore these message to start, but this would avoid a NameError being thrown in `lib/threema/receive.rb`

```rb
def type_instance(type:, params:)
  classify(type).new(params)
end
```
