### PR TITLE
Remove bytesize check to support iOS

### DIFF
--- a/lib/threema/receive/file.rb
+++ b/lib/threema/receive/file.rb
@@ -16,8 +16,6 @@ class Threema
 
         download = blob.download(structure['b'])
 
-        raise "Bytesize doesn't match" if download.bytesize != structure['s']
-
         @content = Threema::E2e::SecretKey.decrypt(
           data:  download,
           key:   Threema::Util.unhexify(structure['k']),


### PR DESCRIPTION
* we will look into whether this is a security issue, but it seems there is a difference in how threema-android and threema-ios sign their encrytped strings and there is a 16-byte authenticator for android, but not for ios. Anyways, we rely on decrypt to validate the authenticity of the nonce, and therefore the sender